### PR TITLE
fix: allow-dirty ci for custom release workflow

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -9,3 +9,4 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 pr-run-mode = "plan"
 unix-archive = ".tar.gz"
 github-attestations = true
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary

Adds `allow-dirty = ["ci"]` to `dist-workspace.toml` so `cargo-dist` accepts our customized `release.yml` (which includes the `sign-artifacts` job).

Without this, the `plan` step fails with exit code 255 because the workflow file doesn't match `cargo-dist`'s expected template.

Made with [Cursor](https://cursor.com)