### PR TITLE
fix: pass minisign password from secret instead of empty string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           for file in *; do
             [ -f "$file" ] || continue
             echo "Signing: $file"
-            echo "" | minisign -Sm "$file" -s /tmp/minisign.key -t "krakenfx/kraken-cli release artifact"
+            printf '%s\n' "$MINISIGN_PASSWORD" | minisign -Sm "$file" -s /tmp/minisign.key -t "krakenfx/kraken-cli release artifact"
             SIGNED=$((SIGNED + 1))
           done
 
@@ -281,7 +281,7 @@ jobs:
           fi
 
           sha256sum * | grep -v '\.minisig$' > SHA256SUMS.txt
-          echo "" | minisign -Sm SHA256SUMS.txt -s /tmp/minisign.key -t "krakenfx/kraken-cli release checksums"
+          printf '%s\n' "$MINISIGN_PASSWORD" | minisign -Sm SHA256SUMS.txt -s /tmp/minisign.key -t "krakenfx/kraken-cli release checksums"
 
           echo "All artifacts signed successfully"
           ls -la *.minisig SHA256SUMS.txt


### PR DESCRIPTION
## Summary

The sign-artifacts step was piping an empty string to minisign as the password, ignoring the `MINISIGN_PASSWORD` secret. This caused signing to fail with "Wrong password for that key".

Replaced `echo ""` with `printf '%s\n' "$MINISIGN_PASSWORD"` for both artifact and checksum signing. The secret is only written to stdin; GitHub masks it in logs automatically.

Made with [Cursor](https://cursor.com)