### PR TITLE
docs: surface full product scope (xStocks, forex, derivatives)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,58 @@ kraken paper buy BTCUSD 0.01 -o json
 kraken paper status -o json
 ```
 
+## Asset Classes
+
+The CLI supports six asset classes through the same command surface. Most commands default to crypto. For other asset classes, pass the `--asset-class` flag.
+
+### Crypto spot (default)
+
+No flag needed. Covers 1,400+ pairs with margin up to 10x on major pairs.
+
+```bash
+kraken ticker BTCUSD -o json
+kraken order buy BTCUSD 0.001 --type limit --price 50000 -o json
+kraken order buy BTCUSD 0.001 --type limit --price 50000 --leverage 5 -o json
+```
+
+### Tokenized U.S. stocks & ETFs (xStocks)
+
+Requires `--asset-class tokenized_asset`. Stock symbols use the `x` suffix: AAPL becomes `AAPLx`, TSLA becomes `TSLAx`. 79 assets available with margin up to 3x on the top 10. Not available in the USA.
+
+```bash
+kraken ticker AAPLx/USD --asset-class tokenized_asset -o json
+kraken order buy AAPLx/USD 0.1 --type limit --price 200 --asset-class tokenized_asset -o json
+kraken order buy TSLAx/USD 0.5 --type limit --price 250 --asset-class tokenized_asset --leverage 3 -o json
+```
+
+To list all xStocks assets: `kraken assets --aclass tokenized_asset -o json`
+
+### Forex
+
+Requires `--asset-class forex` on market data commands. 11 fiat pairs including EUR/USD, GBP/USD, USD/JPY, AUD/USD.
+
+```bash
+kraken ticker EURUSD --asset-class forex -o json
+```
+
+### Futures
+
+Separate engine with its own credentials (`KRAKEN_FUTURES_API_KEY`, `KRAKEN_FUTURES_API_SECRET`). Covers crypto perpetuals, 5 forex perps (PF_EURUSD, PF_GBPUSD, PF_AUDUSD, PF_CHFUSD, PF_JPYUSD), 11 equity/index perps (PF_AAPLXUSD, PF_NVDAXUSD, PF_TSLAXUSD, PF_SPYXUSD, PF_QQQXUSD, PF_SPXUSD, and others), and fixed-date contracts. Leverage up to 50x.
+
+```bash
+kraken futures instruments -o json                                            # list all contracts
+kraken futures order buy PF_XBTUSD 1 --type limit --price 50000 -o json      # crypto perp
+kraken futures order buy PF_AAPLXUSD 10 --type limit --price 200 -o json     # equity perp
+kraken futures order buy FI_XBTUSD_260327 1 --type limit --price 50000 -o json  # fixed-date
+```
+
+### Earn / staking
+
+```bash
+kraken earn strategies --asset ETH -o json
+kraken earn allocate <STRATEGY_ID> 1.0 -o json
+```
+
 ## Output Parsing
 
 ### Success response
@@ -213,7 +265,7 @@ A 0.26% taker fee is applied to all fills (Kraken Starter tier default). Limit o
 |-------|------|----------|-------------|
 | market | No | 10 | Public market data: ticker, orderbook, OHLC, trades, spreads |
 | account | Yes | 18 | Balances, orders, trades, ledgers, positions, export, L3 orderbook |
-| trade | Yes | 9 | Order placement, amendment, cancellation |
+| trade | Yes | 9 | Order placement, amendment, cancellation (spot, xStocks, forex) |
 | funding | Yes | 10 | Deposits, withdrawals, wallet transfers |
 | earn | Yes | 6 | Staking strategies, allocations |
 | subaccount | Yes | 2 | Create subaccounts, transfer between accounts |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Fast entry points:
 
 ## What is kraken-cli?
 
-A command-line interface for the Kraken cryptocurrency exchange. Every command returns structured JSON. Designed for AI agents and automated pipelines.
+A command-line interface for trading crypto, stocks, forex, and derivatives on Kraken. Every command returns structured JSON. Designed for AI agents and automated pipelines.
 
 ## Invocation
 
@@ -74,6 +74,24 @@ kraken order buy BTCUSD 0.001 --type limit --price 50000 --validate -o json
 
 # Then execute (requires user confirmation)
 kraken order buy BTCUSD 0.001 --type limit --price 50000 -o json
+```
+
+### xStocks and forex
+
+Stock symbols use the `x` suffix (AAPL becomes `AAPLx`). Pass `--asset-class tokenized_asset` on trade and market commands. Forex uses `--asset-class forex` on market data.
+
+```bash
+kraken ticker AAPLx/USD --asset-class tokenized_asset -o json
+kraken order buy AAPLx/USD 0.1 --type limit --price 200 --asset-class tokenized_asset -o json
+kraken ticker EURUSD --asset-class forex -o json
+```
+
+### Futures
+
+Futures use a separate engine with separate credentials. Symbols: `PF_XBTUSD` (perp), `FI_XBTUSD_260327` (fixed-date), `PF_AAPLXUSD` (equity perp).
+
+```bash
+kraken futures order buy PF_XBTUSD 1 --type limit --price 50000 -o json
 ```
 
 ### Paper trading (no auth, safe)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,23 @@ export KRAKEN_FUTURES_API_SECRET="your-futures-secret"
 
 Public market data and paper trading do not require credentials.
 
+## Asset Classes
+
+The CLI trades six asset classes through the same command interface. Pass `--asset-class` where required.
+
+| Asset class | Flag | Pair format | Example |
+|---|---|---|---|
+| Crypto spot | _(default, no flag)_ | `BTCUSD`, `BTC/USD` | `kraken order buy BTCUSD 0.001 --type limit --price 50000` |
+| Tokenized stocks & ETFs (xStocks) | `--asset-class tokenized_asset` | `AAPLx/USD`, `TSLAx/USD` | `kraken order buy AAPLx/USD 0.1 --type limit --price 200 --asset-class tokenized_asset` |
+| Forex | `--asset-class forex` | `EURUSD`, `GBPUSD` | `kraken ticker EURUSD --asset-class forex` |
+| Perpetual futures | _(futures engine)_ | `PF_XBTUSD`, `PF_AAPLXUSD` | `kraken futures order buy PF_XBTUSD 1 --type limit --price 50000` |
+| Inverse & fixed-date futures | _(futures engine)_ | `FI_XBTUSD_260327` | `kraken futures order buy FI_XBTUSD_260327 1 --type limit --price 50000` |
+| Earn / staking | — | — | `kraken earn strategies --asset ETH` |
+
+xStocks use the `x` suffix on the ticker symbol (AAPL becomes `AAPLx`, TSLA becomes `TSLAx`). The `--asset-class tokenized_asset` flag is required on trade, market data, and funding commands. xStocks are not available in the USA.
+
+Futures include crypto perps, 5 forex perps (PF_EURUSD, PF_GBPUSD, PF_AUDUSD, PF_CHFUSD, PF_JPYUSD), and 11 equity/index perps (PF_AAPLXUSD, PF_NVDAXUSD, PF_TSLAXUSD, PF_SPYXUSD, PF_QQQXUSD, PF_SPXUSD, and others). Use `kraken futures instruments -o json` to list all available contracts.
+
 ## Safety Rules
 
 1. Never place live orders or withdrawals without explicit human approval.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![license](https://img.shields.io/badge/license-MIT-green)
 ![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
 
-The first AI-native CLI for crypto trading.
+The first AI-native CLI for trading crypto, stocks, forex, and derivatives.
 
 Full Kraken API access. Built-in MCP server. Live and paper trading. Single binary.
 
@@ -16,15 +16,19 @@ Try these with your AI agent:
 
 > *"Watch ETH, SOL, and BTC for 30 seconds. Tell me which one you'd buy and why."*
 
+> *"Look up AAPLx, TSLAx, and SPYx on xStocks. Which one is the better value right now?"*
+
 > *"You are a Wall Street veteran with 20 years of experience. You have 1 minute. Paper trade BTC and show me your P&L."*
 
 ---
 
-**Warning:** Experimental software. Interacts with the live Kraken exchange and can execute real financial transactions. Read [DISCLAIMER.md](DISCLAIMER.md) before using with real funds or AI agents.
+> [!CAUTION]
+> Experimental software. Interacts with the live Kraken exchange and can execute real financial transactions. Read [DISCLAIMER.md](DISCLAIMER.md) before using with real funds or AI agents.
 
 ## Contents
 
 - [Installation](#installation)
+- [What You Can Trade](#what-you-can-trade)
 - [Quick Start](#quick-start)
 - [MCP Server](#mcp-server)
 - [Paper Trading](#paper-trading)
@@ -71,6 +75,21 @@ cargo install --path .
 ```
 </details>
 
+## What You Can Trade
+
+One binary covers six asset classes. All trading commands work across asset classes using the same interface; pass `--asset-class` where needed.
+
+| Asset class | Instruments | Margin | Flag | Example |
+|---|---|---|---|---|
+| **Crypto spot** | 1,400+ pairs (BTC, ETH, SOL, and hundreds more) | Up to 10x on major pairs | _(default)_ | `kraken order buy BTCUSD 0.001 --type limit --price 50000` |
+| **Tokenized U.S. stocks & ETFs ([xStocks](https://www.kraken.com/xstocks))** | 79 assets: AAPL, NVDA, TSLA, GOOGL, AMZN, MSFT, SPY, QQQ, and more | Up to 3x on top 10 | `--asset-class tokenized_asset` | `kraken order buy AAPLx/USD 0.1 --type limit --price 200 --asset-class tokenized_asset` |
+| **Forex** | 11 fiat pairs: EUR/USD, GBP/USD, USD/JPY, AUD/USD, and more | — | `--asset-class forex` | `kraken ticker EURUSD --asset-class forex` |
+| **Perpetual futures** | 317 contracts: crypto, 5 forex perps, 11 equity/index perps (AAPL, NVDA, TSLA, SPY, QQQ, S&P 500) | Up to 50x | _(futures engine)_ | `kraken futures order buy PF_XBTUSD 1 --type limit --price 50000` |
+| **Inverse & fixed-date futures** | 20 contracts: BTC, ETH, SOL, LTC, XRP, ADA, DOGE, LINK | Varies | _(futures engine)_ | `kraken futures order buy FI_XBTUSD_260327 1 --type limit --price 50000` |
+| **Earn / staking** | Flexible and bonded strategies across multiple assets | — | — | `kraken earn strategies --asset ETH` |
+
+*xStocks are not available in the USA. Availability for all products varies by jurisdiction.*
+
 ## For AI Agents
 
 If you're an AI agent or building one, start here:
@@ -103,7 +122,7 @@ Most CLIs are built for humans at a terminal. This one is built for LLM-based ag
 - **Consistent error envelopes.** Errors are JSON objects with a stable `error` field (`auth`, `rate_limit`, `validation`, `api`, `network`). Agents route on `error` without parsing human sentences.
 - **Predictable exit codes.** Success is 0, failure is non-zero. Combined with JSON errors on stdout, agents detect and classify failures programmatically.
 - **Paper trading for safe iteration.** Test strategies against live prices with `kraken paper` commands. No API keys, no real money, same interface.
-- **Full API surface.** 134 commands covering Spot, Futures, Funding, Earn, Subaccounts, and WebSocket streaming.
+- **Full API surface.** 134 commands covering Spot, Futures, xStocks, Forex, Funding, Earn, Subaccounts, and WebSocket streaming.
 - **Built-in MCP server.** Native Model Context Protocol support over stdio. No subprocess wrappers needed.
 - **Rate-limit aware.** Built-in Spot counter/decay and Futures token-bucket rate limiting.
 
@@ -233,12 +252,8 @@ Resolution: CLI flag > environment variable > default. Only `https://` and `wss:
 
 `kraken-cli` includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server over stdio. No subprocess wrappers needed.
 
-Security note:
-- MCP is local-first and designed for your own machine.
-- Any agent connected to this MCP server uses the same configured Kraken account and API key permissions.
-- Do not expose, tunnel, or share this MCP server outside systems you control.
-- Always use `https://` and `wss://` endpoints.
-- Treat this integration as alpha and use least-privilege API keys.
+> [!WARNING]
+> MCP is local-first and designed for your own machine. Any agent connected to this MCP server uses the same configured Kraken account and API key permissions. Do not expose, tunnel, or share this server outside systems you control. Always use `https://` and `wss://` endpoints. Treat this integration as alpha and use least-privilege API keys.
 
 ```bash
 kraken mcp                           # read-only (market, account, paper)
@@ -348,7 +363,7 @@ kraken balance -o json -v 2>/dev/null | jq .
 |-------|----------|------|-------------|
 | market | 10 | No | Ticker, orderbook, OHLC, trades, spreads, asset info |
 | account | 18 | Yes | Balances, orders, trades, ledgers, positions, exports |
-| trade | 9 | Yes | Order placement, amendment, cancellation |
+| trade | 9 | Yes | Order placement, amendment, cancellation (spot, xStocks, forex) |
 | funding | 10 | Yes | Deposits, withdrawals, wallet transfers |
 | earn | 6 | Yes | Staking strategies and allocations |
 | subaccount | 2 | Yes | Create subaccounts, transfer between accounts |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "kraken-cli",
   "version": "0.1.0",
-  "description": "Agent-first CLI for Kraken exchange trading, account, and market operations.",
+  "description": "Agent-first CLI for trading crypto, stocks, forex, and derivatives on Kraken.",
   "contextFileName": "CONTEXT.md",
   "mcpServers": {
     "kraken": {

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # kraken-cli
 
-Agent-first CLI for Kraken exchange operations with structured JSON output.
+Agent-first CLI for trading crypto, stocks, forex, and derivatives on Kraken with structured JSON output.
 
 ## Start Here
 


### PR DESCRIPTION
## Summary

- Add **What You Can Trade** section to README with six asset classes: crypto spot, xStocks, forex, perpetual futures, inverse/fixed-date futures, and earn/staking
- Update tagline from "crypto trading" to "crypto, stocks, forex, and derivatives"
- Add xStocks hero prompt example
- Add Asset Classes sections to CONTEXT.md, AGENTS.md, and CLAUDE.md so agents can discover xStocks (`--asset-class tokenized_asset`), forex (`--asset-class forex`), and equity/index perpetual futures without reading CLI flag descriptions
- Update llms.txt and gemini-extension.json descriptions
- Convert warning and MCP security note to GitHub alert callouts (`[!CAUTION]`, `[!WARNING]`)

## Motivation

The CLI trades six asset classes, but every agent-facing doc (README, CONTEXT.md, AGENTS.md, CLAUDE.md, llms.txt) described it as crypto-only. An agent asked to "buy AAPL" had no path to discover the `x` suffix, the `--asset-class tokenized_asset` flag, or that equity perpetual futures exist.

## Files changed

| File | Change |
|---|---|
| README.md | Tagline, hero prompt, What You Can Trade table, callouts, commands table |
| CONTEXT.md | Asset Classes section with pair formats, flags, examples |
| AGENTS.md | Asset Classes section with subsections and code examples |
| CLAUDE.md | Updated description, xStocks/forex/futures examples |
| llms.txt | Updated description |
| gemini-extension.json | Updated description |

## Test plan

- [x] Verify README renders correctly on GitHub (table, callouts, links)
- [x] Verify all CLI examples in the new sections are valid commands
- [x] No code changes, docs only

Made with [Cursor](https://cursor.com)