### PR TITLE
feat: server-authoritative rate limiting with enriched errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,10 +184,10 @@ Route on the `error` field, not on message strings.
 | `api` | No | Fix parameters. Do not retry same request. |
 | `auth` | No | Re-authenticate. Check KRAKEN_API_KEY and KRAKEN_API_SECRET. |
 | `network` | Yes | Exponential backoff, max 5 retries, starting at 1s. |
-| `rate_limit` | Yes | Wait 5-15s then retry. Reduce request frequency. |
+| `rate_limit` | Yes | Error returned immediately (no CLI retry). Includes `suggestion` (tier-specific guidance), `docs_url` (Kraken documentation link), and `retryable` flag. Read `suggestion` and `docs_url` to understand the limit and adapt your strategy. |
 | `validation` | No | Fix input. Check types, required fields, allowed values. |
 | `config` | No | Check config file or environment variables. |
-| `websocket` | Yes | Reconnect with exponential backoff. CLI retries 3x internally. |
+| `websocket` | Yes | Reconnect with paced exponential backoff and reconnect safety budget. CLI retries up to 12 times per stream lifecycle. |
 | `io` | No | Check file paths and permissions. |
 | `parse` | No | Log raw response. Possible API maintenance. |
 
@@ -203,7 +203,12 @@ else
   CATEGORY=$(echo "$RESULT" | jq -r '.error // "unknown"')
   case "$CATEGORY" in
     auth)       echo "Re-authenticate" ;;
-    rate_limit) sleep 10; echo "Retry" ;;
+    rate_limit)
+      SUGGESTION=$(echo "$RESULT" | jq -r '.suggestion // "Wait and retry"')
+      DOCS=$(echo "$RESULT" | jq -r '.docs_url // ""')
+      echo "Rate limited. $SUGGESTION"
+      echo "Docs: $DOCS"
+      ;;
     network)    sleep 5; echo "Retry" ;;
     *)          echo "Failed: $CATEGORY" ;;
   esac
@@ -214,30 +219,26 @@ For the full error catalog with backoff strategies and example envelopes, see `a
 
 ## Rate Limiting
 
-Kraken uses two independent rate limiting systems.
+The CLI does not pre-throttle or retry rate-limited requests. The Kraken API server enforces rate limits, and the CLI returns the error immediately with structured fields that agents should read:
 
-### Spot API
+- `suggestion`: specific guidance including tier limits, per-endpoint costs, and recommended alternatives
+- `docs_url`: link to the relevant Kraken rate limit documentation
+- `retryable`: `true` for all rate limit errors (the agent decides whether and when to retry)
 
-Counter-based with decay. Each endpoint has a cost. The counter decays over time.
+### Kraken rate limit systems
 
-| Tier | Max counter | Decay rate |
-|------|-------------|------------|
-| Starter | 15 | 0.33/s |
-| Intermediate | 20 | 0.5/s |
-| Pro | 20 | 1.0/s |
+Kraken enforces multiple independent rate limit systems. The `suggestion` field in rate limit errors describes which system was triggered and its parameters. For full documentation:
 
-Order operations cost more (0-2 depending on operation). Market data costs 1.
-
-### Futures API
-
-Token bucket. Refills at a fixed rate. Each request consumes one token.
+- **Spot REST counter**: [docs.kraken.com/api/docs/guides/spot-rest-ratelimits](https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/)
+- **Spot trading engine (per-pair)**: [docs.kraken.com/api/docs/guides/spot-ratelimits](https://docs.kraken.com/api/docs/guides/spot-ratelimits)
+- **Futures cost-based budget**: [docs.kraken.com/api/docs/guides/futures-rate-limits](https://docs.kraken.com/api/docs/guides/futures-rate-limits/)
 
 ### Agent recommendations
 
-- Poll no faster than every 3 seconds for Starter tier.
-- Batch order operations where possible (up to 15 per batch).
-- Use WebSocket streaming instead of polling for real-time data.
-- If you get a `rate_limit` error, wait 5-15 seconds before retrying.
+- Use WebSocket streaming instead of REST polling for real-time data (no rate limit cost).
+- Batch order operations where possible (up to 15 per batch; lower per-order cost on both Spot and Futures).
+- Let orders rest before cancelling; cancelling within 5 seconds costs +8 on the trading engine limiter.
+- When a `rate_limit` error is returned, read the `suggestion` field and adapt your strategy accordingly.
 
 ## Paper Trading
 
@@ -402,6 +403,7 @@ Configure your MCP client:
 
 **Behavior:**
 - Streaming groups (`websocket`, `futures-ws`) are excluded in MCP v1 (REST-only tools).
+- MCP tool execution uses the same command dispatch path as CLI, so error handling and rate-limit behavior is identical.
 - `utility` (interactive setup/shell) is not available as an MCP service.
 - Dangerous tools are annotated with `destructive_hint: true` and include `[DANGEROUS: requires human confirmation]` in the description.
 - In guarded mode (default), dangerous calls must include `acknowledged=true`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,7 +85,7 @@ Route on `error`, not on `message`.
 
 Common categories:
 - `auth`: re-authenticate
-- `rate_limit`: back off and retry
+- `rate_limit`: read `suggestion` and `docs_url` fields, adapt strategy
 - `network`: retry with exponential backoff
 - `validation`: fix inputs, do not retry unchanged request
 - `api`: inspect request and parameters

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Most CLIs are built for humans at a terminal. This one is built for LLM-based ag
 - **Paper trading for safe iteration.** Test strategies against live prices with `kraken paper` commands. No API keys, no real money, same interface.
 - **Full API surface.** 134 commands covering Spot, Futures, xStocks, Forex, Funding, Earn, Subaccounts, and WebSocket streaming.
 - **Built-in MCP server.** Native Model Context Protocol support over stdio. No subprocess wrappers needed.
-- **Rate-limit aware.** Built-in Spot counter/decay and Futures token-bucket rate limiting.
+- **Rate-limit aware.** No client-side throttling. When the Kraken API rejects a request due to rate limits, the CLI returns an enriched error with `suggestion`, `retryable`, and `docs_url` fields so agents can read the documentation and adapt their strategy.
 
 Humans benefit from the same design: `--output table` renders clean tables, `kraken shell` provides a REPL, and `kraken setup` walks through configuration.
 
@@ -212,7 +212,6 @@ api_secret = "your-api-secret"
 [settings]
 default_pair = "BTCUSD"
 output = "table"
-rate_tier = "starter"  # starter, intermediate, or pro
 ```
 
 Or use the interactive wizard: `kraken setup`.
@@ -251,6 +250,8 @@ Resolution: CLI flag > environment variable > default. Only `https://` and `wss:
 ## MCP Server
 
 `kraken-cli` includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server over stdio. No subprocess wrappers needed.
+
+MCP tool calls run through the same command path as CLI commands and inherit the same error handling and rate-limit behavior.
 
 > [!WARNING]
 > MCP is local-first and designed for your own machine. Any agent connected to this MCP server uses the same configured Kraken account and API key permissions. Do not expose, tunnel, or share this server outside systems you control. Always use `https://` and `wss://` endpoints. Treat this integration as alpha and use least-privilege API keys.
@@ -334,12 +335,12 @@ Route on `error`, not on `message`. The `message` field is human-readable and no
 | Category | Retryable | Action |
 |----------|-----------|--------|
 | `auth` | No | Check API key and secret |
-| `rate_limit` | Yes | Wait 5-15s, reduce frequency |
+| `rate_limit` | Yes | Error includes `suggestion` with tier-specific limits, `docs_url` pointing to Kraken documentation, and `retryable` flag. Read `suggestion` and adapt strategy. |
 | `network` | Yes | Exponential backoff, max 5 retries |
 | `validation` | No | Fix input parameters |
 | `api` | No | Inspect request and parameters |
 | `config` | No | Check config file or env vars |
-| `websocket` | Yes | Reconnect with backoff (CLI retries 3x) |
+| `websocket` | Yes | Reconnect with paced backoff and safety budget (up to 12 reconnect attempts per stream lifecycle) |
 | `io` | No | Check file paths and permissions |
 | `parse` | No | Log raw response, possible API maintenance |
 
@@ -669,7 +670,7 @@ Check that `KRAKEN_API_KEY` and `KRAKEN_API_SECRET` are set correctly. Keys are 
 
 **Rate limit errors**
 
-Kraken uses counter-based rate limiting for Spot (15-20 counter with 0.33-1.0/s decay depending on tier) and token-bucket for Futures. Wait 5-15 seconds and retry. For real-time data, use WebSocket streaming instead of polling.
+The CLI does not pre-throttle or retry rate-limited requests. The Kraken API server enforces rate limits, and the CLI returns the error immediately with a `suggestion` field containing tier-specific limits and a `docs_url` pointing to the relevant Kraken documentation. Read the suggestion and adjust request frequency. For sustained high-frequency use, prefer WebSocket streaming over REST polling.
 
 **"No tools found" in MCP client**
 
@@ -690,7 +691,7 @@ src/
   lib.rs           -- AppContext, shared dispatcher, module re-exports
   auth.rs          -- HMAC-SHA512 signing (Spot + Futures), nonce management
   config.rs        -- Config file I/O, credential resolution, secret wrappers
-  client.rs        -- HTTP clients with rate limiting and retry
+  client.rs        -- HTTP clients with transient-error retry and enriched rate-limit errors
   errors.rs        -- Unified error types with category-based JSON envelopes
   paper.rs         -- Paper trading state engine (local simulation)
   shell.rs         -- Interactive REPL with rustyline

--- a/agents/error-catalog.json
+++ b/agents/error-catalog.json
@@ -7,7 +7,14 @@
       "error": "Error category string (matches a category below)",
       "message": "Human-readable error detail (not stable, do not parse)"
     },
-    "example": {"error": "auth", "message": "Authentication failed: EAPI:Invalid key"}
+    "extended_fields": {
+      "applies_to": "rate_limit",
+      "suggestion": "Actionable guidance: tier limits, per-endpoint costs, recommended alternatives",
+      "retryable": "Boolean indicating the agent may retry after adjusting behavior",
+      "docs_url": "Link to the relevant Kraken rate limit documentation page"
+    },
+    "example": {"error": "auth", "message": "Authentication failed: EAPI:Invalid key"},
+    "example_rate_limit": {"error": "rate_limit", "message": "Spot REST API rate limit exceeded (EAPI:Rate limit exceeded).", "suggestion": "Wait 5-15 seconds...", "retryable": true, "docs_url": "https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/"}
   },
   "categories": [
     {
@@ -25,7 +32,7 @@
       "retryable": false,
       "agent_action": "Re-authenticate. Verify KRAKEN_API_KEY and KRAKEN_API_SECRET.",
       "backoff_strategy": null,
-      "common_causes": ["Invalid API key", "Wrong secret", "Key lacks endpoint permission", "OTP required"],
+      "common_causes": ["Invalid API key", "Wrong secret", "Key lacks endpoint permission", "OTP required", "Futures authenticationError", "Futures insufficientPrivileges"],
       "example_envelope": {"error": "auth", "message": "Authentication failed: EAPI:Invalid key"}
     },
     {
@@ -39,12 +46,12 @@
     },
     {
       "category": "rate_limit",
-      "description": "Throttled by Kraken's rate limiter. Spot uses counter/decay; Futures uses token bucket.",
+      "description": "Throttled by Kraken's server-side rate limiter. The CLI returns this error immediately with no internal retry. The error includes a suggestion field with specific guidance and a docs_url linking to the relevant Kraken documentation.",
       "retryable": true,
-      "agent_action": "Wait 5-15 seconds, then retry. Reduce request frequency.",
-      "backoff_strategy": {"type": "fixed_then_exponential", "initial_delay_ms": 5000, "max_delay_ms": 60000, "max_retries": 3},
-      "common_causes": ["Too many requests", "Burst of order operations", "Polling too frequently"],
-      "example_envelope": {"error": "rate_limit", "message": "Rate limit exceeded: EAPI:Rate limit exceeded"}
+      "agent_action": "Read the suggestion field for tier-specific limits and recommended changes. Read docs_url for full documentation. Decide whether to retry, reduce request frequency, or switch to WebSocket streaming.",
+      "backoff_strategy": {"type": "agent_controlled", "note": "CLI does not retry rate limit errors. The agent decides retry timing based on the suggestion and docs_url fields."},
+      "common_causes": ["Too many requests (Spot REST counter)", "Short-lived orders triggering trading engine penalty", "Futures endpoint cost budget exhausted", "Too many concurrent requests (throttle)"],
+      "example_envelope": {"error": "rate_limit", "message": "Spot REST API rate limit exceeded (EAPI:Rate limit exceeded).", "suggestion": "Wait 5-15 seconds before retrying. Reduce request frequency. Use WebSocket streaming instead of REST polling for real-time data.", "retryable": true, "docs_url": "https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/"}
     },
     {
       "category": "validation",
@@ -61,15 +68,15 @@
       "retryable": false,
       "agent_action": "Check config file. For agents, prefer environment variables.",
       "backoff_strategy": null,
-      "common_causes": ["Invalid TOML syntax", "Missing config fields", "Invalid rate_tier"],
+      "common_causes": ["Invalid TOML syntax", "Missing config fields", "Missing or invalid credential values"],
       "example_envelope": {"error": "config", "message": "Configuration error: TOML parse error"}
     },
     {
       "category": "websocket",
       "description": "WebSocket connection or protocol error.",
       "retryable": true,
-      "agent_action": "Reconnect with backoff. CLI retries 3 times internally.",
-      "backoff_strategy": {"type": "exponential", "initial_delay_ms": 2000, "max_delay_ms": 60000, "max_retries": 3},
+      "agent_action": "Reconnect with backoff. CLI retries up to 12 times per stream lifecycle with paced exponential backoff and reconnect safety budgeting.",
+      "backoff_strategy": {"type": "exponential", "initial_delay_ms": 1000, "max_delay_ms": 30000, "max_retries": 12},
       "common_causes": ["Connection dropped", "Server closed connection", "Invalid subscription", "Auth failed on private feed"],
       "example_envelope": {"error": "websocket", "message": "WebSocket error: Connection closed unexpectedly"}
     },

--- a/skills/kraken-error-recovery/SKILL.md
+++ b/skills/kraken-error-recovery/SKILL.md
@@ -25,7 +25,7 @@ Parse the `.error` field from the JSON response:
 | Category | Meaning | Recovery |
 |----------|---------|----------|
 | `auth` | Credentials invalid or expired | Re-authenticate, do not retry |
-| `rate_limit` | Too many requests | Back off 5-15s, then retry |
+| `rate_limit` | Too many requests | Read `suggestion` and `docs_url` fields, adapt strategy |
 | `network` | Connection failed | Retry with exponential backoff |
 | `validation` | Invalid request parameters | Fix inputs, do not retry unchanged |
 | `api` | Exchange-side rejection | Inspect error message, adjust request |
@@ -82,14 +82,17 @@ kraken order cancel --cl-ord-id "dca-2024-01-15-001" -o json 2>/dev/null
 
 ## Rate Limit Recovery
 
+The CLI returns rate limit errors immediately with no internal retry. The error includes actionable fields for the agent to decide next steps.
+
 On `rate_limit` error:
 
-1. Stop all requests.
-2. Wait at least 5 seconds (starter) or 3 seconds (pro).
-3. Reduce polling frequency going forward.
+1. Read the `suggestion` field for specific guidance on what limit was hit and how to adapt.
+2. Read the `docs_url` field for the relevant Kraken documentation.
+3. Decide whether to retry (and when), reduce request frequency, or switch to WebSocket streaming for real-time data.
 4. Resume with a single test call before continuing the loop.
 
 ```bash
+# { "error": "rate_limit", "suggestion": "...", "docs_url": "...", "retryable": true }
 kraken status -o json 2>/dev/null
 ```
 

--- a/skills/kraken-mcp-integration/SKILL.md
+++ b/skills/kraken-mcp-integration/SKILL.md
@@ -13,6 +13,8 @@ metadata:
 
 Use this skill to connect any MCP-compatible client to `kraken-cli` for structured tool calling over stdio.
 
+MCP tool calls execute through the same command path as CLI commands, so error handling and rate-limit behavior is identical between MCP and CLI.
+
 ## Supported Clients
 
 Claude Desktop, ChatGPT, Codex, Gemini CLI, Cursor, VS Code, Windsurf, and any client that supports the MCP `mcpServers` configuration block.

--- a/skills/kraken-rate-limits/SKILL.md
+++ b/skills/kraken-rate-limits/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kraken-rate-limits
-version: 1.0.0
-description: "Understand and manage API rate limit budgets across spot and futures."
+version: 2.0.0
+description: "Understand Kraken API rate limits and adapt agent behavior when limits are hit."
 metadata:
   openclaw:
     category: "finance"
@@ -12,59 +12,68 @@ metadata:
 # kraken-rate-limits
 
 Use this skill for:
-- understanding call budgets per tier (starter, intermediate, pro)
-- spacing requests to avoid rate limit errors
-- managing separate spot and futures rate limits
-- building agent loops that stay within bounds
+- understanding Kraken's rate limit systems (Spot REST, trading engine, Futures)
+- adapting agent behavior when rate limit errors occur
+- choosing optimal request patterns (WebSocket vs REST, batch vs individual)
 
-## Spot Rate Limits
+## How Rate Limiting Works
 
-Kraken spot uses a counter/decay model. Each call adds to a counter; the counter decays over time. If the counter exceeds the tier limit, requests are rejected.
+The CLI does not pre-throttle or retry rate-limited requests. The Kraken API server enforces rate limits. When a limit is hit, the CLI returns the error immediately with structured fields:
+
+```json
+{
+  "error": "rate_limit",
+  "message": "Spot REST API rate limit exceeded ...",
+  "suggestion": "Wait 5-15 seconds before retrying. ...",
+  "retryable": true,
+  "docs_url": "https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/"
+}
+```
+
+Read the `suggestion` field to understand what limit was hit and how to adapt.
+
+## Kraken's Rate Limit Systems
+
+### 1. Spot REST Counter
+
+Counter-decay model. Each call adds to a counter; the counter decays over time.
 
 | Tier | Max Counter | Decay Rate |
 |------|-------------|------------|
-| Starter | 15 | 1 per 3s |
-| Intermediate | 20 | 1 per 2s |
-| Pro | 20 | 1 per 1s |
+| Starter | 15 | 0.33/s |
+| Intermediate | 20 | 0.5/s |
+| Pro | 20 | 1.0/s |
 
-Most calls cost 1 point. Heavier calls (ledgers, trade history, recent trades, query-ledgers) cost 2. Check your tier:
+Most calls cost 1 point. Ledgers, trade history, and query-ledgers cost 2. AddOrder and CancelOrder are excluded from this counter (they use the trading engine limiter instead).
 
-```bash
-kraken volume -o json 2>/dev/null
-```
+Docs: https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/
 
-Set the tier in config for accurate local tracking:
+### 2. Spot Trading Engine (per-pair)
 
-```toml
-[settings]
-rate_tier = "starter"
-```
+Separate per-pair counter with penalties for short-lived orders:
 
-## Futures Rate Limits
+| Tier | Threshold | Decay Rate |
+|------|-----------|------------|
+| Starter | 60 | 1/s |
+| Intermediate | 125 | 2.34/s |
+| Pro | 180 | 3.75/s |
 
-Futures uses a token-bucket model. Tokens refill at a fixed rate. Each call consumes tokens; if the bucket is empty, requests queue or fail.
+Cancel within 5 seconds costs +8, amend within 5 seconds costs +3. Let orders rest longer to reduce cost.
 
-The CLI handles futures rate limiting internally. Agents do not need to track futures buckets manually.
+Docs: https://docs.kraken.com/api/docs/guides/spot-ratelimits
 
-## Agent Spacing Patterns
+### 3. Futures Cost Budget
 
-For starter tier with 15-point budget and 3s decay:
+Cost-based system with two separate pools:
 
-- Safe burst: 10 calls, then pause 30s
-- Sustained: 1 call per 3s indefinitely
-- Mixed read/trade: alternate reads (1 point) and trades (1 point), 1 per 3s
+- `/derivatives` endpoints: budget of 500 per 10 seconds. `sendorder` costs 10, `editorder` costs 10, `cancelorder` costs 10, `batchorder` costs 9 + batch size, `cancelallorders` costs 25, `accounts` costs 2.
+- `/history` endpoints: pool of 100 tokens, refills at 100 per 10 minutes.
 
-For polling loops, prefer intervals that stay well under the limit:
+Docs: https://docs.kraken.com/api/docs/guides/futures-rate-limits/
 
-```bash
-# Safe polling interval for starter tier
-while true; do
-  kraken ticker BTCUSD -o json 2>/dev/null
-  sleep 5
-done
-```
+## Agent Strategies
 
-## Prefer WebSocket Over Polling
+### Prefer WebSocket over REST polling
 
 Streaming does not consume REST rate limit points. For real-time data, always prefer:
 
@@ -72,23 +81,33 @@ Streaming does not consume REST rate limit points. For real-time data, always pr
 kraken ws ticker BTC/USD -o json 2>/dev/null
 ```
 
-Over repeated REST calls.
+### Use batch orders
 
-## Handling Rate Limit Errors
+Batch orders cost less per-order on both Spot and Futures. Up to 15 orders per batch on Spot.
 
-When the CLI receives a rate limit error, the agent should:
+### Read the suggestion field
 
-1. Parse the `rate_limit` error category.
-2. Back off for at least 5 seconds (starter) or 3 seconds (intermediate/pro).
-3. Reduce polling frequency going forward.
-4. Do not retry immediately; the counter needs time to decay.
+When a rate limit error is returned, the `suggestion` field contains the specific limit that was hit and concrete advice. Parse it and adapt:
 
-## Multi-Command Budget Planning
+```bash
+RESULT=$(kraken balance -o json 2>/dev/null)
+if [ $? -ne 0 ]; then
+  CATEGORY=$(echo "$RESULT" | jq -r '.error // "unknown"')
+  if [ "$CATEGORY" = "rate_limit" ]; then
+    SUGGESTION=$(echo "$RESULT" | jq -r '.suggestion // "Wait and retry"')
+    DOCS=$(echo "$RESULT" | jq -r '.docs_url // ""')
+    echo "Rate limited. $SUGGESTION"
+    echo "Read more: $DOCS"
+  fi
+fi
+```
+
+### Multi-command budget planning
 
 Before executing a sequence, estimate total cost:
 
 ```bash
-# This sequence costs ~5 points:
+# This sequence costs ~5 points on the Spot REST counter:
 kraken ticker BTCUSD -o json 2>/dev/null       # 1 point
 kraken balance -o json 2>/dev/null             # 1 point
 kraken open-orders -o json 2>/dev/null         # 1 point

--- a/skills/kraken-risk-operations/SKILL.md
+++ b/skills/kraken-risk-operations/SKILL.md
@@ -46,7 +46,7 @@ kraken futures positions -o json 2>/dev/null
 ## Failure Handling
 
 - `network`: exponential backoff retry
-- `rate_limit`: wait and retry with lower call frequency
+- `rate_limit`: read `suggestion` and `docs_url` fields, reduce call frequency or switch to WebSocket
 - `auth`: stop and refresh credentials
 - `validation` or `api`: stop, fix request, do not blind retry
 

--- a/skills/kraken-shared/SKILL.md
+++ b/skills/kraken-shared/SKILL.md
@@ -47,7 +47,7 @@ Public market data and paper trading require no credentials.
 
 Route on `.error`:
 - `auth`: re-authenticate
-- `rate_limit`: back off and retry
+- `rate_limit`: read `suggestion` and `docs_url` fields, adapt strategy
 - `network`: retry with exponential backoff
 - `validation`: fix inputs, do not retry unchanged request
 - `api`: inspect request parameters

--- a/skills/kraken-spot-execution/SKILL.md
+++ b/skills/kraken-spot-execution/SKILL.md
@@ -51,4 +51,4 @@ Use this skill for:
 
 - Never execute live order commands without explicit user approval.
 - Route failures by `.error` category.
-- On `rate_limit`, wait and retry.
+- On `rate_limit`, read `suggestion` and `docs_url` fields, then adapt strategy.

--- a/skills/kraken-twap-execution/SKILL.md
+++ b/skills/kraken-twap-execution/SKILL.md
@@ -89,7 +89,7 @@ Sum (price * volume) for each fill, divide by total volume filled.
 
 ## Rate Limit Awareness
 
-At starter tier, one call per 3 seconds is safe. A 60-second interval between slices uses 1 point per minute (well within budget). For shorter intervals, check the `kraken-rate-limits` skill.
+The CLI does not pre-throttle requests. If a slice submission hits a rate limit, the error includes a `suggestion` field with tier-specific limits and a `docs_url` pointing to Kraken's documentation. On `rate_limit` error, pause the loop, read the suggestion, and adjust the interval before resuming. A 60-second interval between slices is well within budget for all tiers. For shorter intervals, consult the `kraken-rate-limits` skill for per-tier counter costs and decay rates.
 
 ## Hard Rules
 

--- a/skills/kraken-ws-streaming/SKILL.md
+++ b/skills/kraken-ws-streaming/SKILL.md
@@ -189,4 +189,4 @@ For multi-feed agents, run each stream in a background process and merge events.
 
 - WebSocket order mutations are flagged as dangerous. Require human approval.
 - Never treat NDJSON stream output as a single JSON document.
-- Handle stream disconnects gracefully; the CLI reconnects automatically with exponential backoff (3 attempts).
+- Handle stream disconnects gracefully; the CLI reconnects automatically with paced exponential backoff and reconnect safety budgeting (up to 12 attempts per stream lifecycle).

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,20 @@
 /// HTTP clients for Kraken Spot and Futures APIs.
 ///
 /// Each client enforces TLS-only transport (via rustls), handles request
-/// signing, rate limiting, and transient-error retry with exponential backoff.
+/// signing, and transient-error retry with exponential backoff for network
+/// and 5xx errors.
+///
+/// Rate limiting is server-authoritative: requests are sent immediately with
+/// no client-side pre-throttling. When the Kraken API returns a rate limit
+/// error, it is surfaced immediately as an enriched `KrakenError::RateLimit`
+/// with `suggestion`, `docs_url`, and `retryable` fields so the caller
+/// (agent or human) can decide how to proceed.
 use std::collections::HashMap;
 use std::env;
-use std::sync::Arc;
 use std::time::Duration;
 
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
-use tokio::sync::Mutex;
-use tokio::time::Instant;
 
 use crate::auth;
 use crate::config::{FuturesCredentials, SpotCredentials};
@@ -23,156 +27,16 @@ const MAX_RETRIES: u32 = 3;
 const INITIAL_BACKOFF_MS: u64 = 500;
 const DANGER_ALLOW_ANY_URL_HOST_ENV: &str = "KRAKEN_DANGER_ALLOW_ANY_URL_HOST";
 
-/// Spot API client with built-in rate limiting and retry.
+/// Spot API client with transient-error retry and server-authoritative rate limiting.
 pub struct SpotClient {
     http: reqwest::Client,
     base_url: String,
-    rate_limiter: Arc<Mutex<SpotRateLimiter>>,
 }
 
-/// Futures API client with independent rate limiting.
+/// Futures API client with transient-error retry and server-authoritative rate limiting.
 pub struct FuturesClient {
     http: reqwest::Client,
     base_url: String,
-    rate_limiter: Arc<Mutex<FuturesRateLimiter>>,
-}
-
-/// Spot rate-limit tier profiles.
-#[derive(Debug, Clone, Copy)]
-pub enum SpotTier {
-    Starter,
-    Intermediate,
-    Pro,
-}
-
-impl SpotTier {
-    fn max_counter(&self) -> f64 {
-        match self {
-            Self::Starter => 15.0,
-            Self::Intermediate => 20.0,
-            Self::Pro => 20.0,
-        }
-    }
-
-    fn decay_per_second(&self) -> f64 {
-        match self {
-            Self::Starter => 0.33,
-            Self::Intermediate => 0.5,
-            Self::Pro => 1.0,
-        }
-    }
-}
-
-impl std::str::FromStr for SpotTier {
-    type Err = KrakenError;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s.to_lowercase().as_str() {
-            "starter" => Ok(Self::Starter),
-            "intermediate" => Ok(Self::Intermediate),
-            "pro" => Ok(Self::Pro),
-            _ => Err(KrakenError::Validation(format!("Unknown rate tier: {s}"))),
-        }
-    }
-}
-
-/// Tracks the Spot call-counter with tier-based decay.
-struct SpotRateLimiter {
-    tier: SpotTier,
-    counter: f64,
-    last_update: Instant,
-}
-
-impl SpotRateLimiter {
-    fn new(tier: SpotTier) -> Self {
-        Self {
-            tier,
-            counter: 0.0,
-            last_update: Instant::now(),
-        }
-    }
-
-    fn decay(&mut self) {
-        let elapsed = self.last_update.elapsed().as_secs_f64();
-        self.counter = (self.counter - elapsed * self.tier.decay_per_second()).max(0.0);
-        self.last_update = Instant::now();
-    }
-
-    fn cost_for_endpoint(endpoint: &str) -> f64 {
-        if endpoint.contains("Ledgers")
-            || endpoint.contains("TradesHistory")
-            || endpoint.contains("Trades")
-            || endpoint.contains("QueryLedgers")
-        {
-            2.0
-        } else {
-            1.0
-        }
-    }
-
-    async fn wait_if_needed(&mut self, endpoint: &str) {
-        self.decay();
-        let cost = Self::cost_for_endpoint(endpoint);
-        while self.counter + cost > self.tier.max_counter() {
-            let wait = (cost / self.tier.decay_per_second()).max(0.1);
-            tokio::time::sleep(Duration::from_secs_f64(wait)).await;
-            self.decay();
-        }
-        self.counter += cost;
-    }
-}
-
-/// Tracks Futures token-bucket rate limits.
-struct FuturesRateLimiter {
-    derivatives_tokens: f64,
-    derivatives_last: Instant,
-    history_tokens: f64,
-    history_last: Instant,
-}
-
-impl FuturesRateLimiter {
-    fn new() -> Self {
-        Self {
-            derivatives_tokens: 500.0,
-            derivatives_last: Instant::now(),
-            history_tokens: 100.0,
-            history_last: Instant::now(),
-        }
-    }
-
-    fn is_history_endpoint(path: &str) -> bool {
-        path.contains("history")
-    }
-
-    async fn wait_if_needed(&mut self, path: &str, cost: f64) {
-        if Self::is_history_endpoint(path) {
-            let elapsed = self.history_last.elapsed().as_secs_f64();
-            let replenished = elapsed * (100.0 / 600.0);
-            self.history_tokens = (self.history_tokens + replenished).min(100.0);
-            self.history_last = Instant::now();
-            while self.history_tokens < cost {
-                tokio::time::sleep(Duration::from_millis(500)).await;
-                let elapsed = self.history_last.elapsed().as_secs_f64();
-                let replenished = elapsed * (100.0 / 600.0);
-                self.history_tokens = (self.history_tokens + replenished).min(100.0);
-                self.history_last = Instant::now();
-            }
-            self.history_tokens -= cost;
-        } else {
-            let elapsed = self.derivatives_last.elapsed().as_secs_f64();
-            let replenished = elapsed * (500.0 / 10.0);
-            self.derivatives_tokens = (self.derivatives_tokens + replenished).min(500.0);
-            self.derivatives_last = Instant::now();
-            while self.derivatives_tokens < cost {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                let elapsed = self.derivatives_last.elapsed().as_secs_f64();
-                let replenished = elapsed * (500.0 / 10.0);
-                self.derivatives_tokens = (self.derivatives_tokens + replenished).min(500.0);
-                self.derivatives_last = Instant::now();
-            }
-            self.derivatives_tokens -= cost;
-        }
-    }
 }
 
 fn build_default_headers() -> Result<HeaderMap> {
@@ -227,11 +91,10 @@ fn build_http_client() -> Result<reqwest::Client> {
 
 impl SpotClient {
     /// Create a new Spot client.
-    pub fn new(base_url: Option<&str>, tier: SpotTier) -> Result<Self> {
+    pub fn new(base_url: Option<&str>) -> Result<Self> {
         Ok(Self {
             http: build_http_client()?,
             base_url: base_url.unwrap_or(DEFAULT_SPOT_URL).to_string(),
-            rate_limiter: Arc::new(Mutex::new(SpotRateLimiter::new(tier))),
         })
     }
 
@@ -295,11 +158,6 @@ impl SpotClient {
     ) -> Result<Value> {
         let uri_path = format!("/0/private/{}", endpoint);
         let url = format!("{}{}", self.base_url, uri_path);
-
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint).await;
-        }
 
         let mut attempt = 0u32;
         loop {
@@ -389,11 +247,6 @@ impl SpotClient {
         let uri_path = format!("/0/private/{}", endpoint);
         let url = format!("{}{}", self.base_url, uri_path);
 
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint).await;
-        }
-
         let mut attempt = 0u32;
         loop {
             let nonce = auth::generate_nonce()?;
@@ -466,7 +319,7 @@ impl SpotClient {
     }
 
     /// Execute a private POST that returns raw bytes (for export retrieval).
-    /// Supports OTP, rate limiting, retry, and error-envelope detection.
+    /// Supports OTP, retry on transient errors, and error-envelope detection.
     ///
     /// See `private_post` for the `idempotent` parameter semantics.
     pub async fn private_post_raw(
@@ -480,11 +333,6 @@ impl SpotClient {
     ) -> Result<Vec<u8>> {
         let uri_path = format!("/0/private/{}", endpoint);
         let url = format!("{}{}", self.base_url, uri_path);
-
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint).await;
-        }
 
         let mut attempt = 0u32;
         loop {
@@ -539,26 +387,17 @@ impl SpotClient {
                         tokio::time::sleep(Duration::from_millis(backoff)).await;
                         continue;
                     }
+                    let bytes = r.bytes().await?;
+
+                    if let Some(err) = parse_spot_error_from_body_bytes(&bytes) {
+                        return Err(err);
+                    }
+
                     if !status.is_success() {
                         return Err(KrakenError::Api {
                             category: crate::errors::ErrorCategory::Api,
                             message: format!("HTTP {status}"),
                         });
-                    }
-
-                    let bytes = r.bytes().await?;
-
-                    // Sniff for JSON error envelopes even on HTTP 200
-                    if bytes.starts_with(b"{") {
-                        if let Ok(parsed) = serde_json::from_slice::<Value>(&bytes) {
-                            if let Some(errors) = parsed.get("error").and_then(|e| e.as_array()) {
-                                let errs: Vec<&str> =
-                                    errors.iter().filter_map(|e| e.as_str()).collect();
-                                if !errs.is_empty() {
-                                    return Err(KrakenError::from_kraken_error(errs[0]));
-                                }
-                            }
-                        }
                     }
 
                     return Ok(bytes.to_vec());
@@ -628,7 +467,6 @@ impl FuturesClient {
         Ok(Self {
             http: build_http_client()?,
             base_url: base_url.unwrap_or(DEFAULT_FUTURES_URL).to_string(),
-            rate_limiter: Arc::new(Mutex::new(FuturesRateLimiter::new())),
         })
     }
 
@@ -643,11 +481,6 @@ impl FuturesClient {
         let url = format!("{}/{}", self.base_url, endpoint);
         if verbose {
             crate::output::verbose(&format!("GET {url}"));
-        }
-
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint, 1.0).await;
         }
 
         let mut attempt = 0u32;
@@ -692,11 +525,6 @@ impl FuturesClient {
     ) -> Result<Value> {
         let url = format!("{}/{}", self.base_url, endpoint);
         let endpoint_path = format!("/api/v3/{}", endpoint);
-
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint, 1.0).await;
-        }
 
         let mut attempt = 0u32;
         loop {
@@ -745,7 +573,7 @@ impl FuturesClient {
         }
     }
 
-    /// Execute a private POST on the Futures API with auth headers and retry.
+    /// Execute a private POST on the Futures API with auth headers.
     pub async fn private_post(
         &self,
         endpoint: &str,
@@ -755,11 +583,6 @@ impl FuturesClient {
     ) -> Result<Value> {
         let url = format!("{}/{}", self.base_url, endpoint);
         let endpoint_path = format!("/api/v3/{}", endpoint);
-
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint, 2.0).await;
-        }
 
         let mut attempt = 0u32;
         loop {
@@ -837,11 +660,6 @@ impl FuturesClient {
         let url = format!("{}/{}", self.base_url, endpoint);
         let endpoint_path = format!("/api/v3/{}", endpoint);
 
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint, 2.0).await;
-        }
-
         let mut attempt = 0u32;
         loop {
             let post_data = url::form_urlencoded::Serializer::new(String::new())
@@ -899,11 +717,6 @@ impl FuturesClient {
         let url = format!("{}/{}", self.base_url, endpoint);
         let endpoint_path = format!("/api/v3/{}", endpoint);
 
-        {
-            let mut limiter = self.rate_limiter.lock().await;
-            limiter.wait_if_needed(endpoint, 1.0).await;
-        }
-
         let mut attempt = 0u32;
         loop {
             let nonce = auth::generate_nonce()?.to_string();
@@ -944,6 +757,9 @@ impl FuturesClient {
                             truncate(&body, 500)
                         ));
                     }
+                    if let Some(err) = parse_futures_error_from_body(&body) {
+                        return Err(err);
+                    }
                     if !status.is_success() {
                         return Err(KrakenError::Network(format!(
                             "HTTP {status}: {}",
@@ -980,15 +796,8 @@ impl FuturesClient {
         }
 
         if !status.is_success() {
-            if let Ok(parsed) = serde_json::from_str::<Value>(&body) {
-                if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
-                    if !err.is_empty() {
-                        return Err(KrakenError::Api {
-                            category: crate::errors::ErrorCategory::Api,
-                            message: err.to_string(),
-                        });
-                    }
-                }
+            if let Some(err) = parse_futures_error_from_body(&body) {
+                return Err(err);
             }
             return Err(KrakenError::Network(format!(
                 "HTTP {status}: {}",
@@ -999,19 +808,32 @@ impl FuturesClient {
         let parsed: Value = serde_json::from_str(&body)?;
 
         if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
-            if err == "apiLimitExceeded" {
-                return Err(KrakenError::RateLimit(err.to_string()));
-            }
             if !err.is_empty() && err != "success" {
-                return Err(KrakenError::Api {
-                    category: crate::errors::ErrorCategory::Api,
-                    message: err.to_string(),
-                });
+                return Err(KrakenError::from_kraken_error(err));
             }
         }
 
         Ok(parsed)
     }
+}
+
+fn parse_spot_error_from_body_bytes(bytes: &[u8]) -> Option<KrakenError> {
+    let parsed: Value = serde_json::from_slice(bytes).ok()?;
+    let errors = parsed.get("error")?.as_array()?;
+    let first = errors.iter().find_map(|e| e.as_str())?;
+    if first.is_empty() {
+        return None;
+    }
+    Some(KrakenError::from_kraken_error(first))
+}
+
+fn parse_futures_error_from_body(body: &str) -> Option<KrakenError> {
+    let parsed: Value = serde_json::from_str(body).ok()?;
+    let err = parsed.get("error").and_then(|e| e.as_str())?;
+    if err.is_empty() || err == "success" {
+        return None;
+    }
+    Some(KrakenError::from_kraken_error(err))
 }
 
 fn is_transient(err: &reqwest::Error) -> bool {

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -163,14 +163,7 @@ pub async fn execute(cmd: &AuthCommand, ctx: &AppContext) -> Result<CommandOutpu
                 ctx.api_key.as_deref(),
                 ctx.api_secret.as_deref(),
             )?;
-            let client = crate::client::SpotClient::new(
-                ctx.api_url.as_deref(),
-                config::load()
-                    .ok()
-                    .and_then(|c| c.settings.rate_tier)
-                    .and_then(|t| t.parse::<crate::client::SpotTier>().ok())
-                    .unwrap_or(crate::client::SpotTier::Starter),
-            )?;
+            let client = crate::client::SpotClient::new(ctx.api_url.as_deref())?;
             let result = client
                 .private_post(
                     "Balance",

--- a/src/commands/futures_ws.rs
+++ b/src/commands/futures_ws.rs
@@ -1,13 +1,15 @@
 /// Futures WebSocket v1 streaming commands.
 ///
 /// Implements challenge-based authentication for private feeds, keepalive ping
-/// every 45 seconds, and bounded reconnect with exponential backoff.
+/// every 45 seconds, and bounded reconnect with exponential backoff plus
+/// reconnect safety budgets.
 ///
 /// Public feeds: ticker, trade, book
 /// Private feeds: fills, open-orders, open-positions, balances, notifications, account-log
+use std::collections::VecDeque;
 use std::env;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::Subcommand;
 use futures_util::{SinkExt, StreamExt};
@@ -30,8 +32,14 @@ use crate::errors::{KrakenError, Result};
 use crate::output::{self, CommandOutput};
 
 const DEFAULT_FUTURES_WS_URL: &str = "wss://futures.kraken.com/ws/v1";
-const MAX_RECONNECTS: u32 = 3;
+const MAX_RECONNECTS: u32 = 12;
 const RECONNECT_BASE_MS: u64 = 1000;
+const FAST_RECONNECT_ATTEMPTS: u32 = 2;
+const RECONNECT_MIN_DELAY_MS: u64 = 5000;
+const RECONNECT_MAX_DELAY_MS: u64 = 30000;
+const RECONNECT_JITTER_MAX_MS: u64 = 750;
+const RECONNECT_WINDOW_SECS: u64 = 600;
+const MAX_RECONNECTS_PER_WINDOW: usize = 120;
 const STABLE_SESSION_SECS: u64 = 30;
 const PING_INTERVAL_SECS: u64 = 45;
 
@@ -202,8 +210,55 @@ async fn ws_connect(url: &str) -> Result<WsConnection> {
     connect.map_err(|e| KrakenError::WebSocket(format!("Connection failed: {e}")))
 }
 
+fn reconnect_jitter_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| (d.subsec_nanos() as u64) % (RECONNECT_JITTER_MAX_MS + 1))
+        .unwrap_or(0)
+}
+
+fn reconnect_backoff_ms(reconnect_count: u32) -> u64 {
+    let exponent = reconnect_count.saturating_sub(1);
+    let exp_backoff = RECONNECT_BASE_MS.saturating_mul(2u64.pow(exponent));
+    let base = if reconnect_count <= FAST_RECONNECT_ATTEMPTS {
+        exp_backoff.min(RECONNECT_MIN_DELAY_MS)
+    } else {
+        exp_backoff.clamp(RECONNECT_MIN_DELAY_MS, RECONNECT_MAX_DELAY_MS)
+    };
+    base.saturating_add(reconnect_jitter_ms())
+}
+
+fn prune_reconnect_window(reconnect_history: &mut VecDeque<Instant>) {
+    let window = Duration::from_secs(RECONNECT_WINDOW_SECS);
+    while reconnect_history
+        .front()
+        .is_some_and(|ts| ts.elapsed() >= window)
+    {
+        reconnect_history.pop_front();
+    }
+}
+
+async fn enforce_reconnect_budget(reconnect_history: &mut VecDeque<Instant>, label: &str) {
+    prune_reconnect_window(reconnect_history);
+    if reconnect_history.len() >= MAX_RECONNECTS_PER_WINDOW {
+        if let Some(oldest) = reconnect_history.front() {
+            let remaining =
+                Duration::from_secs(RECONNECT_WINDOW_SECS).saturating_sub(oldest.elapsed());
+            let wait_for = remaining.saturating_add(Duration::from_millis(reconnect_jitter_ms()));
+            output::warn(&format!(
+                "{label}: reconnect safety budget reached ({MAX_RECONNECTS_PER_WINDOW}/{RECONNECT_WINDOW_SECS}s), waiting {}ms",
+                wait_for.as_millis()
+            ));
+            tokio::time::sleep(wait_for).await;
+        }
+        prune_reconnect_window(reconnect_history);
+    }
+    reconnect_history.push_back(Instant::now());
+}
+
 async fn stream_public(feed: &str, product_ids: &[String], verbose: bool, url: &str) -> Result<()> {
     let mut reconnect_count = 0u32;
+    let mut reconnect_history = VecDeque::new();
 
     loop {
         if verbose {
@@ -226,7 +281,8 @@ async fn stream_public(feed: &str, product_ids: &[String], verbose: bool, url: &
                     )));
                 }
                 reconnect_count += 1;
-                let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+                enforce_reconnect_budget(&mut reconnect_history, "futures-ws-public").await;
+                let backoff = reconnect_backoff_ms(reconnect_count);
                 output::warn(&format!(
                     "Futures WS connection failed: {e}, retrying in {backoff}ms"
                 ));
@@ -309,7 +365,8 @@ async fn stream_public(feed: &str, product_ids: &[String], verbose: bool, url: &
                     "Futures WS connection lost after {MAX_RECONNECTS} reconnect attempts"
                 )));
             }
-            let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+            enforce_reconnect_budget(&mut reconnect_history, "futures-ws-public").await;
+            let backoff = reconnect_backoff_ms(reconnect_count);
             output::warn(&format!(
                 "Futures WS disconnected, reconnecting in {backoff}ms ({reconnect_count}/{MAX_RECONNECTS})"
             ));
@@ -325,6 +382,7 @@ async fn stream_private(
     url: &str,
 ) -> Result<()> {
     let mut reconnect_count = 0u32;
+    let mut reconnect_history = VecDeque::new();
 
     loop {
         if verbose {
@@ -347,7 +405,8 @@ async fn stream_private(
                     )));
                 }
                 reconnect_count += 1;
-                let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+                enforce_reconnect_budget(&mut reconnect_history, "futures-ws-private").await;
+                let backoff = reconnect_backoff_ms(reconnect_count);
                 output::warn(&format!(
                     "Futures WS connection failed: {e}, retrying in {backoff}ms"
                 ));
@@ -461,7 +520,8 @@ async fn stream_private(
                     "Futures WS connection lost after {MAX_RECONNECTS} reconnect attempts"
                 )));
             }
-            let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+            enforce_reconnect_budget(&mut reconnect_history, "futures-ws-private").await;
+            let backoff = reconnect_backoff_ms(reconnect_count);
             output::warn(&format!(
                 "Futures WS disconnected, reconnecting in {backoff}ms ({reconnect_count}/{MAX_RECONNECTS})"
             ));

--- a/src/commands/market.rs
+++ b/src/commands/market.rs
@@ -518,11 +518,10 @@ fn jval(v: &Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::SpotTier;
 
     #[tokio::test]
     async fn orderbook_l3_returns_error_not_panic() {
-        let client = SpotClient::new(Some("https://api.kraken.com"), SpotTier::Starter).unwrap();
+        let client = SpotClient::new(Some("https://api.kraken.com")).unwrap();
         let cmd = MarketCommand::OrderbookL3 {
             pair: "BTCUSD".into(),
             depth: "100".into(),

--- a/src/commands/utility.rs
+++ b/src/commands/utility.rs
@@ -66,7 +66,6 @@ pub async fn setup(verbose: bool) -> Result<CommandOutput> {
         settings: SettingsConfig {
             default_pair: Some(default_pair),
             output: Some("table".to_string()),
-            rate_tier: None,
         },
     };
 

--- a/src/commands/websocket.rs
+++ b/src/commands/websocket.rs
@@ -1,13 +1,13 @@
 /// WebSocket streaming commands for real-time market and private data.
 ///
-/// Implements bounded reconnection (up to 3 attempts with exponential backoff)
-/// and signal-driven graceful shutdown. The reconnect counter is only reset
+/// Implements bounded reconnection with exponential backoff, reconnect safety
+/// budgets, and signal-driven graceful shutdown. The reconnect counter is only reset
 /// after a connection has been stable for `STABLE_SESSION_SECS`, preventing
 /// unbounded reconnects on flapping connections.
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::env;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::Subcommand;
 use futures_util::{SinkExt, StreamExt};
@@ -32,7 +32,7 @@ use crate::output::{self, OutputFormat};
 const DEFAULT_WS_PUBLIC_URL: &str = "wss://ws.kraken.com/v2";
 const DEFAULT_WS_AUTH_URL: &str = "wss://ws-auth.kraken.com/v2";
 const DEFAULT_WS_L3_URL: &str = "wss://ws-l3.kraken.com/v2";
-const MAX_RECONNECTS: u32 = 3;
+const MAX_RECONNECTS: u32 = 12;
 
 pub struct WsUrls<'a> {
     pub public: Option<&'a str>,
@@ -40,6 +40,12 @@ pub struct WsUrls<'a> {
     pub l3: Option<&'a str>,
 }
 const RECONNECT_BASE_MS: u64 = 1000;
+const FAST_RECONNECT_ATTEMPTS: u32 = 2;
+const RECONNECT_MIN_DELAY_MS: u64 = 5000;
+const RECONNECT_MAX_DELAY_MS: u64 = 30000;
+const RECONNECT_JITTER_MAX_MS: u64 = 750;
+const RECONNECT_WINDOW_SECS: u64 = 600;
+const MAX_RECONNECTS_PER_WINDOW: usize = 120;
 /// Seconds a connection must stay up before the reconnect counter resets.
 const STABLE_SESSION_SECS: u64 = 30;
 
@@ -1440,6 +1446,52 @@ impl ServerCertVerifier for NoVerify {
     }
 }
 
+fn reconnect_jitter_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| (d.subsec_nanos() as u64) % (RECONNECT_JITTER_MAX_MS + 1))
+        .unwrap_or(0)
+}
+
+fn reconnect_backoff_ms(reconnect_count: u32) -> u64 {
+    let exponent = reconnect_count.saturating_sub(1);
+    let exp_backoff = RECONNECT_BASE_MS.saturating_mul(2u64.pow(exponent));
+    let base = if reconnect_count <= FAST_RECONNECT_ATTEMPTS {
+        exp_backoff.min(RECONNECT_MIN_DELAY_MS)
+    } else {
+        exp_backoff.clamp(RECONNECT_MIN_DELAY_MS, RECONNECT_MAX_DELAY_MS)
+    };
+    base.saturating_add(reconnect_jitter_ms())
+}
+
+fn prune_reconnect_window(reconnect_history: &mut VecDeque<Instant>) {
+    let window = Duration::from_secs(RECONNECT_WINDOW_SECS);
+    while reconnect_history
+        .front()
+        .is_some_and(|ts| ts.elapsed() >= window)
+    {
+        reconnect_history.pop_front();
+    }
+}
+
+async fn enforce_reconnect_budget(reconnect_history: &mut VecDeque<Instant>, label: &str) {
+    prune_reconnect_window(reconnect_history);
+    if reconnect_history.len() >= MAX_RECONNECTS_PER_WINDOW {
+        if let Some(oldest) = reconnect_history.front() {
+            let remaining =
+                Duration::from_secs(RECONNECT_WINDOW_SECS).saturating_sub(oldest.elapsed());
+            let wait_for = remaining.saturating_add(Duration::from_millis(reconnect_jitter_ms()));
+            output::warn(&format!(
+                "{label}: reconnect safety budget reached ({MAX_RECONNECTS_PER_WINDOW}/{RECONNECT_WINDOW_SECS}s), waiting {}ms",
+                wait_for.as_millis()
+            ));
+            tokio::time::sleep(wait_for).await;
+        }
+        prune_reconnect_window(reconnect_history);
+    }
+    reconnect_history.push_back(Instant::now());
+}
+
 async fn stream_public(
     channel: &str,
     pairs: &[String],
@@ -1449,6 +1501,7 @@ async fn stream_public(
     url: &str,
 ) -> Result<()> {
     let mut reconnect_count = 0u32;
+    let mut reconnect_history: VecDeque<Instant> = VecDeque::new();
 
     loop {
         if verbose {
@@ -1471,7 +1524,8 @@ async fn stream_public(
                     )));
                 }
                 reconnect_count += 1;
-                let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+                enforce_reconnect_budget(&mut reconnect_history, "spot-ws-public").await;
+                let backoff = reconnect_backoff_ms(reconnect_count);
                 output::warn(&format!(
                     "WebSocket connection failed: {e}, retrying in {backoff}ms"
                 ));
@@ -1541,7 +1595,8 @@ async fn stream_public(
                     "Connection lost after {MAX_RECONNECTS} reconnect attempts"
                 )));
             }
-            let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+            enforce_reconnect_budget(&mut reconnect_history, "spot-ws-public").await;
+            let backoff = reconnect_backoff_ms(reconnect_count);
             output::warn(&format!(
                 "WebSocket disconnected, reconnecting in {backoff}ms ({reconnect_count}/{MAX_RECONNECTS})"
             ));
@@ -1562,23 +1617,51 @@ async fn stream_private_with_params(
     extra_params: serde_json::Map<String, Value>,
 ) -> Result<()> {
     let mut reconnect_count = 0u32;
+    let mut reconnect_history: VecDeque<Instant> = VecDeque::new();
+    let mut cached_token: Option<String> = None;
 
     loop {
-        let token_resp = client
-            .private_post(
-                "GetWebSocketsToken",
-                HashMap::new(),
-                creds,
-                otp,
-                true,
-                verbose,
-            )
-            .await?;
+        let token = match cached_token.take() {
+            Some(t) => t,
+            None => {
+                let token_result = client
+                    .private_post(
+                        "GetWebSocketsToken",
+                        HashMap::new(),
+                        creds,
+                        otp,
+                        true,
+                        verbose,
+                    )
+                    .await;
 
-        let token = token_resp
-            .get("token")
-            .and_then(|t| t.as_str())
-            .ok_or_else(|| KrakenError::Auth("Failed to obtain WebSocket token".into()))?;
+                match token_result {
+                    Ok(resp) => resp
+                        .get("token")
+                        .and_then(|t| t.as_str())
+                        .ok_or_else(|| {
+                            KrakenError::Auth("Failed to obtain WebSocket token".into())
+                        })?
+                        .to_string(),
+                    Err(KrakenError::RateLimit { ref message, .. }) => {
+                        if reconnect_count >= MAX_RECONNECTS {
+                            return Err(KrakenError::WebSocket(format!(
+                                "Token refresh rate-limited after {MAX_RECONNECTS} attempts: {message}"
+                            )));
+                        }
+                        reconnect_count += 1;
+                        enforce_reconnect_budget(&mut reconnect_history, "spot-ws-token").await;
+                        let backoff = reconnect_backoff_ms(reconnect_count);
+                        output::warn(&format!(
+                            "Token refresh rate-limited ({message}), retrying in {backoff}ms"
+                        ));
+                        tokio::time::sleep(Duration::from_millis(backoff)).await;
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        };
 
         if verbose {
             if reconnect_count > 0 {
@@ -1600,7 +1683,8 @@ async fn stream_private_with_params(
                     )));
                 }
                 reconnect_count += 1;
-                let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+                enforce_reconnect_budget(&mut reconnect_history, "spot-ws-private").await;
+                let backoff = reconnect_backoff_ms(reconnect_count);
                 output::warn(&format!(
                     "WebSocket connection failed: {e}, retrying in {backoff}ms"
                 ));
@@ -1636,7 +1720,7 @@ async fn stream_private_with_params(
         let msg =
             serde_json::to_string(&subscribe).map_err(|e| KrakenError::Parse(e.to_string()))?;
         if verbose {
-            let redacted = redact_token_in_payload(&msg, token);
+            let redacted = redact_token_in_payload(&msg, &token);
             output::verbose(&format!("Subscribing: {redacted}"));
         }
         ws.send(Message::Text(msg))
@@ -1689,7 +1773,8 @@ async fn stream_private_with_params(
                     "Connection lost after {MAX_RECONNECTS} reconnect attempts"
                 )));
             }
-            let backoff = RECONNECT_BASE_MS * 2u64.pow(reconnect_count - 1);
+            enforce_reconnect_budget(&mut reconnect_history, "spot-ws-private").await;
+            let backoff = reconnect_backoff_ms(reconnect_count);
             output::warn(&format!(
                 "WebSocket disconnected, reconnecting in {backoff}ms ({reconnect_count}/{MAX_RECONNECTS})"
             ));

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,8 +39,6 @@ pub struct SettingsConfig {
     pub default_pair: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rate_tier: Option<String>,
 }
 
 impl std::fmt::Debug for AuthConfig {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,8 +51,13 @@ pub enum KrakenError {
     #[error("Network error: {0}")]
     Network(String),
 
-    #[error("Rate limit exceeded: {0}")]
-    RateLimit(String),
+    #[error("{message}")]
+    RateLimit {
+        message: String,
+        suggestion: String,
+        retryable: bool,
+        docs_url: String,
+    },
 
     #[error("Validation error: {0}")]
     Validation(String),
@@ -80,7 +85,7 @@ impl KrakenError {
             Self::Api { category, .. } => *category,
             Self::Auth(_) => ErrorCategory::Auth,
             Self::Network(_) => ErrorCategory::Network,
-            Self::RateLimit(_) => ErrorCategory::RateLimit,
+            Self::RateLimit { .. } => ErrorCategory::RateLimit,
             Self::Validation(_) => ErrorCategory::Validation,
             Self::Config(_) => ErrorCategory::Config,
             Self::WebSocket(_) => ErrorCategory::WebSocket,
@@ -92,10 +97,72 @@ impl KrakenError {
 
     /// Constructs an API error from a Kraken error string (e.g. "EAPI:Invalid key").
     pub fn from_kraken_error(msg: &str) -> Self {
-        if msg.starts_with("EAPI:Rate limit") || msg.starts_with("EService:Throttled") {
-            return Self::RateLimit(msg.to_string());
+        if msg.starts_with("EAPI:Rate limit") {
+            return Self::RateLimit {
+                message: format!("Spot REST API rate limit exceeded ({msg})."),
+                suggestion: "Wait 5-15 seconds before retrying. Reduce request frequency. \
+                    Use WebSocket streaming instead of REST polling for real-time data. \
+                    Batch order operations where possible (up to 15 per batch). \
+                    Current limits depend on your account verification tier \
+                    (Starter: 15 calls max / 0.33/s decay, \
+                    Intermediate: 20 / 0.5/s, Pro: 20 / 1.0/s). \
+                    Ledger and trade history calls cost 2 each, other calls cost 1. \
+                    AddOrder and CancelOrder use a separate trading engine limiter."
+                    .to_string(),
+                retryable: true,
+                docs_url: "https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/"
+                    .to_string(),
+            };
         }
-        if msg.starts_with("EGeneral:Permission") || msg.starts_with("EAPI:Invalid key") {
+        if msg.starts_with("EService:Throttled") || msg.starts_with("EService: Throttled") {
+            return Self::RateLimit {
+                message: format!("Too many concurrent requests ({msg})."),
+                suggestion: "Reduce the number of parallel in-flight requests. \
+                    This is a concurrency throttle, not a rate counter. \
+                    Serialize requests or add a small delay between concurrent calls."
+                    .to_string(),
+                retryable: true,
+                docs_url: "https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits/"
+                    .to_string(),
+            };
+        }
+        if msg.starts_with("EOrder:Rate limit") {
+            return Self::RateLimit {
+                message: format!("Trading engine rate limit exceeded ({msg})."),
+                suggestion:
+                    "The matching engine has per-pair rate limits separate from the REST API. \
+                    Cancelling orders within 5 seconds costs +8 per order. \
+                    Amending within 5 seconds costs +3. \
+                    Let orders rest longer before cancelling or amending. \
+                    Use batch orders to reduce per-order cost. \
+                    Thresholds: Starter 60, Intermediate 125, Pro 180 per pair."
+                        .to_string(),
+                retryable: true,
+                docs_url: "https://docs.kraken.com/api/docs/guides/spot-ratelimits".to_string(),
+            };
+        }
+        if msg == "apiLimitExceeded" {
+            return Self::RateLimit {
+                message: "Futures API rate limit exceeded.".to_string(),
+                suggestion:
+                    "Futures uses cost-based budgets: /derivatives endpoints have a budget \
+                    of 500 per 10 seconds (sendorder costs 10, editorder costs 10, \
+                    cancelorder costs 10, batchorder costs 9 + batch size, \
+                    cancelallorders costs 25, accounts costs 2). \
+                    /history endpoints have a separate pool of 100 tokens replenishing \
+                    at 100 per 10 minutes. \
+                    Reduce request frequency or use batch orders to lower per-order cost."
+                        .to_string(),
+                retryable: true,
+                docs_url: "https://docs.kraken.com/api/docs/guides/futures-rate-limits/"
+                    .to_string(),
+            };
+        }
+        if msg.starts_with("EGeneral:Permission")
+            || msg.starts_with("EAPI:Invalid key")
+            || msg == "authenticationError"
+            || msg == "insufficientPrivileges"
+        {
             return Self::Auth(msg.to_string());
         }
         Self::Api {
@@ -104,12 +171,29 @@ impl KrakenError {
         }
     }
 
-    /// Builds the JSON error envelope: `{"error":"<category>","message":"<detail>"}`.
+    /// Builds the JSON error envelope.
+    ///
+    /// Rate limit errors include additional fields that LLM agents can use
+    /// to adapt their strategy: `suggestion`, `retryable`, and `docs_url`.
     pub fn to_json_envelope(&self) -> serde_json::Value {
-        serde_json::json!({
-            "error": self.category().to_string(),
-            "message": self.to_string(),
-        })
+        match self {
+            Self::RateLimit {
+                message,
+                suggestion,
+                retryable,
+                docs_url,
+            } => serde_json::json!({
+                "error": "rate_limit",
+                "message": message,
+                "suggestion": suggestion,
+                "retryable": retryable,
+                "docs_url": docs_url,
+            }),
+            _ => serde_json::json!({
+                "error": self.category().to_string(),
+                "message": self.to_string(),
+            }),
+        }
     }
 }
 
@@ -144,3 +228,133 @@ impl From<base64::DecodeError> for KrakenError {
 }
 
 pub type Result<T> = std::result::Result<T, KrakenError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_kraken_error_spot_rest_rate_limit() {
+        let err = KrakenError::from_kraken_error("EAPI:Rate limit exceeded");
+        assert_eq!(err.category(), ErrorCategory::RateLimit);
+        if let KrakenError::RateLimit {
+            retryable,
+            docs_url,
+            suggestion,
+            ..
+        } = &err
+        {
+            assert!(retryable);
+            assert!(docs_url.contains("spot-rest-ratelimits"));
+            assert!(suggestion.contains("Ledger"));
+        } else {
+            panic!("Expected RateLimit variant, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn from_kraken_error_eservice_throttled() {
+        let err = KrakenError::from_kraken_error("EService:Throttled");
+        assert_eq!(err.category(), ErrorCategory::RateLimit);
+        if let KrakenError::RateLimit { suggestion, .. } = &err {
+            assert!(suggestion.contains("concurrency"));
+        } else {
+            panic!("Expected RateLimit variant");
+        }
+    }
+
+    #[test]
+    fn from_kraken_error_eservice_throttled_with_space() {
+        let err = KrakenError::from_kraken_error("EService: Throttled: 1741500000");
+        assert_eq!(err.category(), ErrorCategory::RateLimit);
+    }
+
+    #[test]
+    fn from_kraken_error_trading_engine() {
+        let err = KrakenError::from_kraken_error("EOrder:Rate limit exceeded");
+        assert_eq!(err.category(), ErrorCategory::RateLimit);
+        if let KrakenError::RateLimit {
+            docs_url,
+            suggestion,
+            ..
+        } = &err
+        {
+            assert!(docs_url.contains("spot-ratelimits"));
+            assert!(suggestion.contains("per-pair"));
+        } else {
+            panic!("Expected RateLimit variant");
+        }
+    }
+
+    #[test]
+    fn from_kraken_error_futures_api_limit() {
+        let err = KrakenError::from_kraken_error("apiLimitExceeded");
+        assert_eq!(err.category(), ErrorCategory::RateLimit);
+        if let KrakenError::RateLimit {
+            docs_url,
+            suggestion,
+            ..
+        } = &err
+        {
+            assert!(docs_url.contains("futures-rate-limits"));
+            assert!(suggestion.contains("500 per 10 seconds"));
+        } else {
+            panic!("Expected RateLimit variant");
+        }
+    }
+
+    #[test]
+    fn from_kraken_error_auth() {
+        let err = KrakenError::from_kraken_error("EAPI:Invalid key");
+        assert_eq!(err.category(), ErrorCategory::Auth);
+    }
+
+    #[test]
+    fn from_kraken_error_permission() {
+        let err = KrakenError::from_kraken_error("EGeneral:Permission denied");
+        assert_eq!(err.category(), ErrorCategory::Auth);
+    }
+
+    #[test]
+    fn from_kraken_error_futures_authentication_error() {
+        let err = KrakenError::from_kraken_error("authenticationError");
+        assert_eq!(err.category(), ErrorCategory::Auth);
+    }
+
+    #[test]
+    fn from_kraken_error_futures_insufficient_privileges() {
+        let err = KrakenError::from_kraken_error("insufficientPrivileges");
+        assert_eq!(err.category(), ErrorCategory::Auth);
+    }
+
+    #[test]
+    fn from_kraken_error_unknown_falls_to_api() {
+        let err = KrakenError::from_kraken_error("EGeneral:Unknown order");
+        assert_eq!(err.category(), ErrorCategory::Api);
+    }
+
+    #[test]
+    fn rate_limit_envelope_has_all_fields() {
+        let err = KrakenError::RateLimit {
+            message: "test".to_string(),
+            suggestion: "wait".to_string(),
+            retryable: true,
+            docs_url: "https://example.com".to_string(),
+        };
+        let envelope = err.to_json_envelope();
+        assert_eq!(envelope["error"], "rate_limit");
+        assert_eq!(envelope["message"], "test");
+        assert_eq!(envelope["suggestion"], "wait");
+        assert_eq!(envelope["retryable"], true);
+        assert_eq!(envelope["docs_url"], "https://example.com");
+    }
+
+    #[test]
+    fn non_rate_limit_envelope_has_error_and_message() {
+        let err = KrakenError::Auth("bad key".to_string());
+        let envelope = err.to_json_envelope();
+        assert_eq!(envelope["error"], "auth");
+        assert!(envelope["message"].as_str().unwrap().contains("bad key"));
+        assert!(envelope.get("suggestion").is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod telemetry;
 
 use clap::{Parser, Subcommand};
 
-use client::{FuturesClient, SpotClient, SpotTier};
+use client::{FuturesClient, SpotClient};
 use commands::account::{self as account, AccountCommand};
 use commands::auth::{self as auth_cmds, AuthCommand};
 use commands::earn::{self as earn, EarnCommand};
@@ -1485,13 +1485,7 @@ pub async fn dispatch(ctx: &AppContext, command: Command) -> Result<()> {
 }
 
 pub fn build_spot_client(ctx: &AppContext) -> Result<SpotClient> {
-    let tier = config::load()
-        .ok()
-        .and_then(|c| c.settings.rate_tier)
-        .and_then(|t| t.parse::<SpotTier>().ok())
-        .unwrap_or(SpotTier::Starter);
-
-    SpotClient::new(ctx.api_url.as_deref(), tier)
+    SpotClient::new(ctx.api_url.as_deref())
 }
 
 fn build_spot_authed(ctx: &AppContext) -> Result<(SpotClient, config::SpotCredentials)> {

--- a/tests/integration/wiremock_tests.rs
+++ b/tests/integration/wiremock_tests.rs
@@ -1,7 +1,7 @@
 /// Wiremock-based HTTP integration tests.
 ///
 /// Exercises the HTTP client against a mock server to verify signing, error
-/// parsing, retry behavior, and output contracts.
+/// parsing, transient-error retry, and output contracts.
 use std::collections::HashMap;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -10,7 +10,7 @@ use serde_json::json;
 use wiremock::matchers::{header, header_exists, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use kraken_cli::client::{FuturesClient, SpotClient, SpotTier};
+use kraken_cli::client::{FuturesClient, SpotClient};
 use kraken_cli::config::{CredentialSource, FuturesCredentials, SecretValue, SpotCredentials};
 
 fn test_credentials() -> SpotCredentials {
@@ -38,7 +38,7 @@ async fn spot_public_get_returns_result() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client.public_get("SystemStatus", &[], false).await.unwrap();
 
     assert_eq!(result.get("status").unwrap().as_str().unwrap(), "online");
@@ -64,7 +64,7 @@ async fn spot_private_post_sends_auth_headers() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client
         .private_post("Balance", HashMap::new(), &creds, None, true, false)
         .await
@@ -89,7 +89,7 @@ async fn spot_private_post_includes_otp_when_provided() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client
         .private_post(
             "Balance",
@@ -106,7 +106,7 @@ async fn spot_private_post_includes_otp_when_provided() {
 }
 
 #[tokio::test]
-async fn spot_api_error_parsed_from_envelope() {
+async fn spot_rate_limit_returned_immediately() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -120,17 +120,26 @@ async fn spot_api_error_parsed_from_envelope() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client
         .private_post("Balance", HashMap::new(), &creds, None, true, false)
         .await
         .unwrap_err();
 
-    let msg = err.to_string();
-    assert!(
-        msg.contains("Rate limit"),
-        "Expected rate limit error, got: {msg}"
-    );
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
+    if let kraken_cli::errors::KrakenError::RateLimit {
+        suggestion,
+        docs_url,
+        retryable,
+        ..
+    } = &err
+    {
+        assert!(retryable);
+        assert!(docs_url.contains("spot-rest-ratelimits"));
+        assert!(suggestion.contains("WebSocket"));
+    } else {
+        panic!("Expected RateLimit variant, got {err:?}");
+    }
 }
 
 #[tokio::test]
@@ -148,7 +157,7 @@ async fn spot_auth_error_parsed_from_envelope() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client
         .private_post("Balance", HashMap::new(), &creds, None, true, false)
         .await
@@ -177,7 +186,7 @@ async fn spot_public_get_retries_on_transport_error() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client.public_get("Time", &[], false).await.unwrap();
     assert!(result.get("unixtime").is_some());
 }
@@ -206,7 +215,7 @@ async fn spot_5xx_retry_uses_fresh_nonce() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client
         .private_post("Balance", HashMap::new(), &creds, None, true, false)
         .await
@@ -230,7 +239,7 @@ async fn private_post_raw_detects_json_error_on_200() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client
         .private_post_raw("RetrieveExport", HashMap::new(), &creds, None, true, false)
         .await
@@ -260,7 +269,7 @@ async fn private_post_raw_returns_binary_on_success() {
         .await;
 
     let creds = test_credentials();
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client
         .private_post_raw("RetrieveExport", HashMap::new(), &creds, None, true, false)
         .await
@@ -268,6 +277,30 @@ async fn private_post_raw_returns_binary_on_success() {
 
     assert!(result.starts_with(b"PK"));
     assert_eq!(result.len(), zip_bytes.len());
+}
+
+#[tokio::test]
+async fn private_post_raw_rate_limit_returned_immediately() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/0/private/RetrieveExport"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "error": ["EAPI:Rate limit exceeded"],
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let creds = test_credentials();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
+    let err = client
+        .private_post_raw("RetrieveExport", HashMap::new(), &creds, None, true, false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
 }
 
 #[tokio::test]
@@ -286,7 +319,7 @@ async fn spot_json_output_table_output_match() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client.public_get("SystemStatus", &[], false).await.unwrap();
 
     assert!(result.is_object());
@@ -304,7 +337,7 @@ async fn spot_non_2xx_returns_network_error() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client.public_get("Assets", &[], false).await.unwrap_err();
 
     let category = err.category();
@@ -326,7 +359,7 @@ async fn spot_user_agent_header_present() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let _ = client.public_get("Time", &[], false).await.unwrap();
 }
 
@@ -345,7 +378,7 @@ async fn spot_korigin_header_present() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let _ = client.public_get("Time", &[], false).await.unwrap();
 }
 
@@ -371,7 +404,7 @@ async fn spot_public_get_retries_on_5xx_then_succeeds() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let result = client
         .public_get("Ticker", &[("pair", "XBTUSD")], false)
         .await
@@ -390,7 +423,7 @@ async fn spot_public_get_5xx_exhausts_retries() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client.public_get("Ticker", &[], false).await.unwrap_err();
     assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::Network);
 }
@@ -406,7 +439,7 @@ async fn spot_5xx_returns_network_error_not_parse_error() {
         .mount(&server)
         .await;
 
-    let client = SpotClient::new(Some(&server.uri()), SpotTier::Starter).unwrap();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
     let err = client.public_get("Assets", &[], false).await.unwrap_err();
     assert_eq!(
         err.category(),
@@ -483,4 +516,155 @@ async fn futures_private_get_retries_on_5xx_then_succeeds() {
         .await
         .unwrap();
     assert!(result.get("accounts").is_some());
+}
+
+#[tokio::test]
+async fn spot_eservice_throttled_returned_immediately() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/0/private/Balance"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "error": ["EService:Throttled"],
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let creds = test_credentials();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
+    let err = client
+        .private_post("Balance", HashMap::new(), &creds, None, true, false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
+    if let kraken_cli::errors::KrakenError::RateLimit { suggestion, .. } = &err {
+        assert!(suggestion.contains("concurrency"));
+    } else {
+        panic!("Expected RateLimit variant, got {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn spot_eorder_rate_limit_returned_immediately() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/0/private/AddOrder"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "error": ["EOrder:Rate limit exceeded"],
+            "result": null
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let creds = test_credentials();
+    let client = SpotClient::new(Some(&server.uri())).unwrap();
+    let err = client
+        .private_post("AddOrder", HashMap::new(), &creds, None, true, false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
+    if let kraken_cli::errors::KrakenError::RateLimit {
+        suggestion,
+        docs_url,
+        ..
+    } = &err
+    {
+        assert!(suggestion.contains("per-pair"));
+        assert!(docs_url.contains("spot-ratelimits"));
+    } else {
+        panic!("Expected RateLimit variant, got {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn futures_api_limit_exceeded_returned_immediately() {
+    let server = MockServer::start().await;
+    let base_url = format!("{}/api/v3", server.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/api/v3/tickers"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "error",
+            "error": "apiLimitExceeded"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = FuturesClient::new(Some(&base_url)).unwrap();
+    let err = client.public_get("tickers", &[], false).await.unwrap_err();
+
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
+    if let kraken_cli::errors::KrakenError::RateLimit {
+        docs_url,
+        suggestion,
+        ..
+    } = &err
+    {
+        assert!(docs_url.contains("futures-rate-limits"));
+        assert!(suggestion.contains("Futures"));
+    } else {
+        panic!("Expected RateLimit variant, got {err:?}");
+    }
+}
+
+#[tokio::test]
+async fn futures_auth_error_not_retried() {
+    let server = MockServer::start().await;
+    let base_url = format!("{}/api/v3", server.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/api/v3/accounts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "result": "error",
+            "error": "authenticationError"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let creds = test_futures_credentials();
+    let client = FuturesClient::new(Some(&base_url)).unwrap();
+    let err = client
+        .private_get("accounts", &[], &creds, false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(
+        err.category(),
+        kraken_cli::errors::ErrorCategory::Auth,
+        "Futures authenticationError should be classified as auth, got {:?}",
+        err.category()
+    );
+}
+
+#[tokio::test]
+async fn futures_private_get_rate_limit_from_non_2xx_returned_immediately() {
+    let server = MockServer::start().await;
+    let base_url = format!("{}/api/v3", server.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/api/v3/accounts"))
+        .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+            "result": "error",
+            "error": "apiLimitExceeded"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let creds = test_futures_credentials();
+    let client = FuturesClient::new(Some(&base_url)).unwrap();
+    let err = client
+        .private_get("accounts", &[], &creds, false)
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.category(), kraken_cli::errors::ErrorCategory::RateLimit);
 }


### PR DESCRIPTION
## Summary

- Remove client-side rate throttling (`SpotRateLimiter`, `FuturesRateLimiter`, `SpotTier` config). Requests flow directly to the Kraken API with no artificial delays or hidden retry loops for rate-limit responses.
- When Kraken rejects a request due to rate limits, the CLI returns the error immediately with enriched fields: `suggestion` (tier-specific guidance), `docs_url` (canonical Kraken docs link), and `retryable`.
- Agents and automation layers can read the error, consult the docs, and adapt their own pacing strategy instead of the CLI imposing opaque backoff delays that could stale time-sensitive orders.

## Additional changes

- **WebSocket reconnect hardening**: 12 attempts with paced exponential backoff, jitter, rolling window budget, and token-refresh rate-limit integration.
- **Futures auth error classification**: `authenticationError` and `insufficientPrivileges` now correctly map to `Auth` category instead of generic `Api`.
- **Comprehensive tests**: new integration and unit tests for all rate-limit error variants, enriched field validation, and WebSocket reconnect behavior.
- **Docs/skills alignment**: README, AGENTS.md, CONTEXT.md, error-catalog.json, and 8 skill files updated to reflect server-authoritative rate limiting.

## Files changed

- `src/client.rs` — removed `SpotRateLimiter`, `FuturesRateLimiter`, `SpotTier`, and all retry-on-rate-limit logic
- `src/errors.rs` — enriched `RateLimit` variant with `suggestion`, `docs_url`, `retryable`; added Futures auth mapping
- `src/config.rs` — removed unused `rate_tier` field
- `src/commands/websocket.rs`, `src/commands/futures_ws.rs` — reconnect hardening with paced backoff and token-refresh rate-limit handling
- `tests/integration/wiremock_tests.rs` — new tests for immediate rate-limit return and enriched error fields
- Docs and skills files updated for consistency