### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraken-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Kraken CLI — trade, query, and manage your Kraken account from the terminal"
 license = "MIT"


### PR DESCRIPTION
## Summary

Bump `Cargo.toml` version from `0.1.0` to `0.2.0` to prepare for the next release.

## Release steps after merge

1. Pull latest `main`
2. Tag: `git tag v0.2.0`
3. Push tag: `git push origin v0.2.0`
4. The release workflow builds binaries, signs with minisign, and creates the GitHub Release automatically.