### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "kraken-cli"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraken-cli"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 description = "Kraken CLI — trade, query, and manage your Kraken account from the terminal"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.3 to 0.3.0

## What's in 0.3.0

### Futures paper trading (`kraken futures paper`)

Complete derivatives simulation engine with 17 new subcommands mirroring live `kraken futures order`:

- **Order types:** market, limit, post, stop, take-profit, ioc, trailing-stop, fok
- **Position management:** long/short positions, position aggregation/netting, reduce-only orders
- **Margin and leverage:** 1x-200x leverage, margin tracking, per-symbol leverage preferences
- **Risk simulation:** liquidation simulation based on mark price, funding rate accrual
- **Order management:** edit, cancel, cancel-all, batch-order
- **Full isolation:** separate state from spot paper, no API credentials required

### Spot paper slippage simulation

- Optional flat-rate slippage for spot paper market orders via `--slippage-rate`

### Other

- Config file permissions TOCTOU fix
- Contribution guidelines and public sync docs

## Changes

- `Cargo.toml`: version 0.2.3 -> 0.3.0
- `Cargo.lock`: updated automatically

Made with [Cursor](https://cursor.com)