### PR TITLE
fix: use relativeFundingRate for paper trading funding calculation

### DIFF
--- a/src/commands/futures_paper.rs
+++ b/src/commands/futures_paper.rs
@@ -441,7 +441,7 @@ async fn fetch_funding_rate(client: &FuturesClient, symbol: &str, verbose: bool)
 
     rates
         .last()
-        .and_then(|entry| entry.get("fundingRate").and_then(|v| v.as_f64()))
+        .and_then(|entry| entry.get("relativeFundingRate").and_then(|v| v.as_f64()))
         .ok_or_else(|| KrakenError::Parse("No funding rate entries".into()))
 }
 


### PR DESCRIPTION
The historical-funding-rates API returns two fields:
- fundingRate: absolute/annualized rate
- relativeFundingRate: actual per-interval rate

Paper trading was using fundingRate, which overcharges by ~7000x.