### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "kraken-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kraken-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Kraken CLI — trade, query, and manage your Kraken account from the terminal"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release v0.3.1.

## Changes since v0.3.0

- fix: use relativeFundingRate for paper trading funding calculation (#28)
- chore: fixes and improvements for earn skill (#29)